### PR TITLE
Implement definition object into QT

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
                                  Apache License
-                           Version 2.0, January 2004
+                           Version 2.0, January 2004a
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
                                  Apache License
-                           Version 2.0, January 2004a
+                           Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,18 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fix
+        :tags: publisher,assembler,opener
+
+        Updated progress widget style and appearance of finalizer section.
+
+
+    .. change:: change
+        :tags: publisher,assembler,opener
+
+        Use core pipeline DefinitionObject API instead of raw definition dictionary operations.
+
+
     .. change:: change
         :tags: assembler
 

--- a/resource/sass/widget/_group_box.scss
+++ b/resource/sass/widget/_group_box.scss
@@ -1,6 +1,13 @@
 QGroupBox {
     color: $text-color;
     background: transparent !important;
+    border: 1px solid $border-color;
+    padding-top: 7px;
+}
+
+QGroupBox::title {
+    color: $text-color;
+    font-size: 0.7em;
 }
 
 QGroupBox::indicator {

--- a/source/ftrack_connect_pipeline_qt/client/load/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/load/__init__.py
@@ -8,7 +8,6 @@ from Qt import QtCore, QtWidgets
 
 from ftrack_connect_pipeline.utils import str_version
 from ftrack_connect_pipeline import constants as core_constants
-from ftrack_connect_pipeline.constants import plugin
 from ftrack_connect_pipeline.client.loader import LoaderClient
 from ftrack_connect_pipeline_qt.ui.utility.widget.button import (
     AddRunButton,
@@ -446,21 +445,16 @@ class QtAssemblerClientWidget(QtLoaderClient, dialog.Dialog):
                 try:
                     # Set method to importer plugins
                     if method:
-                        for component in definition['components']:
-                            for stage in component['stages']:
-                                if (
-                                    stage['type']
-                                    != plugin._PLUGIN_IMPORTER_TYPE
-                                ):
-                                    continue
-                                for _plugin in stage['plugins']:
-                                    if (
-                                        _plugin['type']
-                                        != plugin._PLUGIN_IMPORTER_TYPE
-                                    ):
-                                        continue
-                                    _plugin['default_method'] = method
-
+                        for plugin in definition.get_all(
+                            category=core_constants.PLUGIN,
+                            type=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
+                        ):
+                            plugin['default_method'] = method
+                    print(
+                        '@@@ definition to run: {}'.format(
+                            definition.to_json(indent=2)
+                        )
+                    )
                     self.run_definition(definition, engine_type)
                     # Did it go well?
                     if factory.has_error:

--- a/source/ftrack_connect_pipeline_qt/client/load/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/load/__init__.py
@@ -450,11 +450,6 @@ class QtAssemblerClientWidget(QtLoaderClient, dialog.Dialog):
                             type=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
                         ):
                             plugin['default_method'] = method
-                    print(
-                        '@@@ definition to run: {}'.format(
-                            definition.to_json(indent=2)
-                        )
-                    )
                     self.run_definition(definition, engine_type)
                     # Did it go well?
                     if factory.has_error:

--- a/source/ftrack_connect_pipeline_qt/client/open/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/open/__init__.py
@@ -217,7 +217,7 @@ class QtOpenerClientWidget(QtOpenerClient, dialog.Dialog):
 
     # Definition
 
-    def change_definition(self, schema, definition, component_names_filter):
+    def change_definition(self, definition, schema, component_names_filter):
         '''
         Triggered when _on_change_definition is called within the definition selector.
         Generates the widgets interface from the given *schema* and *definition*
@@ -232,7 +232,7 @@ class QtOpenerClientWidget(QtOpenerClient, dialog.Dialog):
             self.refresh()
             return
 
-        super(QtOpenerClientWidget, self).change_definition(schema, definition)
+        super(QtOpenerClientWidget, self).change_definition(definition, schema)
 
         asset_type_name = definition['asset_type']
 

--- a/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
@@ -224,7 +224,7 @@ class QtPublisherClientWidget(QtPublisherClient, QtWidgets.QFrame):
 
     def change_definition(self, definition, schema, component_names_filter):
         '''
-        Triggered when definition_changed F called from the host_selector.
+        Triggered when definition_changed is called from the host_selector.
         Generates the widgets interface from the given *schema* and *definition*
         '''
         self._component_names_filter = component_names_filter

--- a/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
@@ -222,9 +222,9 @@ class QtPublisherClientWidget(QtPublisherClient, QtWidgets.QFrame):
 
     # Definition
 
-    def change_definition(self, schema, definition, component_names_filter):
+    def change_definition(self, definition, schema, component_names_filter):
         '''
-        Triggered when definition_changed is called from the host_selector.
+        Triggered when definition_changed F called from the host_selector.
         Generates the widgets interface from the given *schema* and *definition*
         '''
         self._component_names_filter = component_names_filter
@@ -235,7 +235,7 @@ class QtPublisherClientWidget(QtPublisherClient, QtWidgets.QFrame):
             return
 
         super(QtPublisherClientWidget, self).change_definition(
-            schema, definition
+            definition, schema
         )
 
         asset_type_name = definition['asset_type']

--- a/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
+++ b/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
@@ -5,6 +5,8 @@ from functools import partial
 
 from Qt import QtWidgets, QtCore
 
+from ftrack_connect_pipeline.definition.definition_object import DefinitionList
+
 from ftrack_connect_pipeline_qt.plugin.widget import BaseOptionsWidget
 from ftrack_connect_pipeline_qt.ui.utility.widget import group_box
 
@@ -34,6 +36,7 @@ class DynamicWidget(BaseOptionsWidget):
             int: self._build_int_widget,
             float: self._build_float_widget,
             list: self._build_list_widget,
+            DefinitionList: self._build_list_widget,
             bool: self._build_bool_widget,
         }
         super(DynamicWidget, self).__init__(

--- a/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
+++ b/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
@@ -36,7 +36,6 @@ class DynamicWidget(BaseOptionsWidget):
             int: self._build_int_widget,
             float: self._build_float_widget,
             list: self._build_list_widget,
-            DefinitionList: self._build_list_widget,
             bool: self._build_bool_widget,
         }
         super(DynamicWidget, self).__init__(
@@ -226,6 +225,8 @@ class DynamicWidget(BaseOptionsWidget):
             # want to expose these within the UI
             if key.find('_') == 0:
                 continue
+            if isinstance(value, DefinitionList):
+                value = value.to_list()
             value_type = type(value)
             widget_fn = self._type_mapping.get(
                 value_type, self._build_str_widget

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
@@ -9,6 +9,10 @@ from Qt import QtCore, QtWidgets
 from ftrack_connect_pipeline import constants as core_constants
 from ftrack_connect_pipeline.client import constants
 from ftrack_connect_pipeline.constants import plugin
+from ftrack_connect_pipeline.definition.definition_object import (
+    DefinitionObject,
+    DefinitionList,
+)
 from ftrack_connect_pipeline_qt.ui.asset_manager.model import AssetListModel
 from ftrack_connect_pipeline_qt.ui.asset_manager.base import (
     AssetListWidget,
@@ -44,7 +48,6 @@ from ftrack_connect_pipeline_qt.ui.utility.widget import (
     icon,
     overlay,
     scroll_area,
-    line,
 )
 
 
@@ -53,6 +56,9 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
 
     stopBusyIndicator = QtCore.Signal()
     listWidgetCreated = QtCore.Signal(object)
+    loadError = QtCore.Signal(
+        object
+    )  # Emitted if a critical error occurs during load
 
     @property
     def component_list(self):
@@ -235,6 +241,7 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
         self._rb_match_component_name.clicked.connect(self.rebuild)
         self._rb_match_extension.clicked.connect(self.rebuild)
         self.stopBusyIndicator.connect(self._stop_busy_indicator)
+        self.loadError.connect(self._on_load_error)
 
     def update(self):
         '''Update widget inputs'''
@@ -251,6 +258,11 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
         self._busy_widget.setVisible(False)
         self._rebuild_button.setVisible(True)
 
+    def _on_load_error(self, error_message):
+        self.client.progress_widget.set_status(
+            constants.WARNING_STATUS, error_message
+        )
+
     def mousePressEvent(self, event):
         if event.button() != QtCore.Qt.RightButton and self._component_list:
             self._component_list.clear_selection()
@@ -266,10 +278,7 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
         self.client.logger.debug(
             'Available loader definitions: {}'.format(
                 '\n'.join(
-                    [
-                        json.dumps(loader, indent=4)
-                        for loader in loader_definitions
-                    ]
+                    [loader.to_json(indent=4) for loader in loader_definitions]
                 )
             )
         )
@@ -344,7 +353,9 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
                         )
                         continue
                     definition_fragment = None
-                    for d_component in definition.get('components', []):
+                    for d_component in definition.get_all(
+                        type=core_constants.COMPONENT
+                    ):
                         component_name_effective = d_component['name']
                         if (
                             component_name_effective.lower()
@@ -363,41 +374,51 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
                         if set(file_formats).intersection(
                             set([component_extension])
                         ):
-                            # Construct fragment
-                            definition_fragment = {
-                                'components': [copy.deepcopy(d_component)]
-                            }
-                            definition_fragment['components'][0][
-                                'name'
-                            ] = component_name_effective
+                            # Construct definition fragment
+                            definition_fragment = DefinitionObject({})
                             for key in definition:
-                                if key not in [
-                                    'components',
-                                ]:
+                                if key == core_constants.COMPONENTS:
+                                    definition_fragment[key] = DefinitionList(
+                                        [
+                                            DefinitionObject(
+                                                d_component.to_dict()
+                                            )
+                                        ]
+                                    )
+                                    definition_fragment.get_first(
+                                        type=core_constants.COMPONENT
+                                    )['name'] = component_name_effective
+                                else:
+                                    # Copy the category
                                     definition_fragment[key] = copy.deepcopy(
                                         definition[key]
                                     )
-                                    if key == core_constants.CONTEXTS:
-                                        # Remove open context
-                                        for stage in definition_fragment[key][
-                                            0
-                                        ]['stages']:
-                                            for plugin in stage['plugins']:
-                                                if not 'options' in plugin:
-                                                    plugin['options'] = {}
-                                                # Store version
-                                                plugin['options'][
-                                                    'asset_name'
-                                                ] = version['asset']['name']
-                                                plugin['options'][
-                                                    'asset_id'
-                                                ] = version['asset']['id']
-                                                plugin['options'][
-                                                    'version_number'
-                                                ] = version['version']
-                                                plugin['options'][
-                                                    'version_id'
-                                                ] = version['id']
+                                    if key != core_constants.CONTEXTS:
+                                        continue
+                                    # Remove open context
+                                    for stage in (
+                                        definition_fragment[key]
+                                        .get_first(type=core_constants.CONTEXT)
+                                        .get_all(category=core_constants.STAGE)
+                                    ):
+                                        for plugin in stage.get_all(
+                                            category=core_constants.PLUGIN
+                                        ):
+                                            if not 'options' in plugin:
+                                                plugin['options'] = {}
+                                            # Store version
+                                            plugin['options'][
+                                                'asset_name'
+                                            ] = version['asset']['name']
+                                            plugin['options'][
+                                                'asset_id'
+                                            ] = version['asset']['id']
+                                            plugin['options'][
+                                                'version_number'
+                                            ] = version['version']
+                                            plugin['options'][
+                                                'version_id'
+                                            ] = version['id']
                         else:
                             self.client.logger.debug(
                                 '        File formats {} does not intersect with {}!'.format(
@@ -667,26 +688,32 @@ class ComponentBaseWidget(AccordionBaseWidget):
         self._set_default_mode()
 
     def _set_default_mode(self):
-        '''Find out from definition which is the default load mode and set it'''
+        '''Find out from which is the default load mode and set it'''
         mode = self._modes[0]
-        for stage in self.definition['components'][0]['stages']:
-            if stage['name'] == plugin._PLUGIN_IMPORTER_TYPE:
-                if not 'options' in stage['plugins'][0]:
-                    stage['plugins'][0]['options'] = {}
-                mode = stage['plugins'][0]['options'].get(
-                    'load_mode', 'import'
-                )
-                break
+        stage = self.definition.get_first(
+            type=core_constants.COMPONENT
+        ).get_first(
+            category=core_constants.STAGE,
+            name=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
+        )
+        plugin = stage.get_first(category=core_constants.PLUGIN)
+        if not 'options' in plugin:
+            plugin['options'] = {}
+        mode = plugin['options'].get('load_mode', 'import')
         self._mode_selector.setCurrentIndex(self._modes.index(mode))
 
     def _mode_selected(self, index):
         '''Load mode has been selected, store in definition'''
         mode = self._mode_selector.itemData(index)
         # Store mode in working definition
-        for stage in self.definition['components'][0]['stages']:
-            if stage['name'] == plugin._PLUGIN_IMPORTER_TYPE:
-                stage['plugins'][0]['options']['load_mode'] = mode
-                break
+        stage = self.definition.get_first(
+            type=core_constants.COMPONENT
+        ).get_first(
+            category=core_constants.STAGE,
+            name=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
+        )
+        plugin = stage.get_first(category=core_constants.PLUGIN)
+        plugin['options']['load_mode'] = mode
 
     def _build_options(self):
         '''Build options overlay with factory'''

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
@@ -398,8 +398,8 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
                                     # Inject context ident
                                     for plugin in (
                                         definition_fragment[key]
-                                        .get_first(type=core_constants.CONTEXT)
                                         .get_all(
+                                            type=core_constants.CONTEXT,
                                             category=core_constants.PLUGIN
                                         )
                                     ):

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
@@ -395,30 +395,29 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
                                     )
                                     if key != core_constants.CONTEXTS:
                                         continue
-                                    # Remove open context
-                                    for stage in (
+                                    # Inject context ident
+                                    for plugin in (
                                         definition_fragment[key]
                                         .get_first(type=core_constants.CONTEXT)
-                                        .get_all(category=core_constants.STAGE)
-                                    ):
-                                        for plugin in stage.get_all(
+                                        .get_all(
                                             category=core_constants.PLUGIN
-                                        ):
-                                            if not 'options' in plugin:
-                                                plugin['options'] = {}
-                                            # Store version
-                                            plugin['options'][
-                                                'asset_name'
-                                            ] = version['asset']['name']
-                                            plugin['options'][
-                                                'asset_id'
-                                            ] = version['asset']['id']
-                                            plugin['options'][
-                                                'version_number'
-                                            ] = version['version']
-                                            plugin['options'][
-                                                'version_id'
-                                            ] = version['id']
+                                        )
+                                    ):
+                                        if not 'options' in plugin:
+                                            plugin['options'] = {}
+                                        # Store version
+                                        plugin['options'][
+                                            'asset_name'
+                                        ] = version['asset']['name']
+                                        plugin['options'][
+                                            'asset_id'
+                                        ] = version['asset']['id']
+                                        plugin['options'][
+                                            'version_number'
+                                        ] = version['version']
+                                        plugin['options'][
+                                            'version_id'
+                                        ] = version['id']
                         else:
                             self.client.logger.debug(
                                 '        File formats {} does not intersect with {}!'.format(
@@ -690,29 +689,23 @@ class ComponentBaseWidget(AccordionBaseWidget):
     def _set_default_mode(self):
         '''Find out from which is the default load mode and set it'''
         mode = self._modes[0]
-        stage = self.definition.get_first(
-            type=core_constants.COMPONENT
-        ).get_first(
-            category=core_constants.STAGE,
-            name=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
+        plugin = self.definition.get_first(
+            category=core_constants.PLUGIN,
+            type=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
         )
-        plugin = stage.get_first(category=core_constants.PLUGIN)
         if not 'options' in plugin:
             plugin['options'] = {}
-        mode = plugin['options'].get('load_mode', 'import')
+        mode = plugin['options'].get('load_mode', mode)
         self._mode_selector.setCurrentIndex(self._modes.index(mode))
 
     def _mode_selected(self, index):
         '''Load mode has been selected, store in definition'''
         mode = self._mode_selector.itemData(index)
         # Store mode in working definition
-        stage = self.definition.get_first(
-            type=core_constants.COMPONENT
-        ).get_first(
-            category=core_constants.STAGE,
-            name=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
+        plugin = self.definition.get_first(
+            category=core_constants.PLUGIN,
+            type=core_constants.plugin._PLUGIN_IMPORTER_TYPE,
         )
-        plugin = stage.get_first(category=core_constants.PLUGIN)
         plugin['options']['load_mode'] = mode
 
     def _build_options(self):

--- a/source/ftrack_connect_pipeline_qt/ui/factory/assembler.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/assembler.py
@@ -73,34 +73,22 @@ class AssemblerWidgetFactory(OpenerAssemblerWidgetFactoryBase):
 
     def build_progress_ui(self, component):
         '''Build only progress widget components, prepare to run.'''
-
-        types = [
-            core_constants.CONTEXTS,
-            core_constants.COMPONENTS,
-            core_constants.FINALIZERS,
-        ]
-
-        for type_name in types:
-            for step in self.definition[type_name]:
-                step_type = step['type']
-                step_name = step.get('name')
-                if (
-                    self.progress_widget
-                    and step_type != 'finalizer'
-                    and step.get('visible', True) is True
-                ):
+        if not self.progress_widget:
+            return
+        for step in self.definition.get_all(category=core_constants.STEP):
+            step_type = step['type']
+            step_name = step.get('name')
+            if step_type != core_constants.FINALIZER:
+                if step.get('visible', True) is True:
                     self.progress_widget.add_step(
                         step_type,
                         step_name,
                         version_id=component['version']['id'],
                     )
-                for stage in step['stages']:
+            else:
+                for stage in step.get_all(category=core_constants.STAGE):
                     stage_name = stage.get('name')
-                    if (
-                        self.progress_widget
-                        and step_type == 'finalizer'
-                        and stage.get('visible', True) is True
-                    ):
+                    if stage.get('visible', True) is True:
                         self.progress_widget.add_step(
                             step_type,
                             stage_name,

--- a/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
@@ -231,9 +231,9 @@ class ProgressWidgetObject(BaseUIWidgetObject):
         )
         self.content_widget.layout().addWidget(self.status_banner)
 
-    def add_step(self, step_type, name, version_id=None, label=None):
-        id_name = "{}.{}.{}".format(version_id or '-', step_type, name)
-        step_button = PhaseButton(label or name, "Not started")
+    def add_step(self, step_type, step_name, version_id=None, label=None):
+        id_name = "{}.{}.{}".format(version_id or '-', step_type, step_name)
+        step_button = PhaseButton(label or step_name, "Not started")
         self._step_widgets[id_name] = step_button
         if step_type not in self.step_types:
             self.step_types.append(step_type)
@@ -275,7 +275,6 @@ class ProgressWidgetObject(BaseUIWidgetObject):
                     ('{}.'.format(version_id)) if version_id else '',
                     step_type,
                     step_name,
-                    id_name,
                     status_message,
                 )
                 self.widget.set_status(status, message=main_status_message)

--- a/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
@@ -231,13 +231,14 @@ class ProgressWidgetObject(BaseUIWidgetObject):
         )
         self.content_widget.layout().addWidget(self.status_banner)
 
-    def add_step(self, step_type, step_name, version_id=None):
-        id_name = "{}.{}.{}".format(version_id or '-', step_type, step_name)
-        step_button = PhaseButton(step_name, "Not started")
+    def add_step(self, step_type, name, version_id=None, label=None):
+        id_name = "{}.{}.{}".format(version_id or '-', step_type, name)
+        step_button = PhaseButton(label or name, "Not started")
         self._step_widgets[id_name] = step_button
         if step_type not in self.step_types:
             self.step_types.append(step_type)
-            step_title = QtWidgets.QLabel(step_type.title())
+            step_title = QtWidgets.QLabel(step_type.upper())
+            step_title.setObjectName("gray")
             self.content_widget.layout().addWidget(step_title)
         self.content_widget.layout().addWidget(step_button)
 
@@ -270,7 +271,13 @@ class ProgressWidgetObject(BaseUIWidgetObject):
                 status, status_message, results
             )
             if status != self.widget.get_status():
-                main_status_message = '{}: {}'.format(id_name, status_message)
+                main_status_message = '{}{}.{}: {}'.format(
+                    ('{}.'.format(version_id)) if version_id else '',
+                    step_type,
+                    step_name,
+                    id_name,
+                    status_message,
+                )
                 self.widget.set_status(status, message=main_status_message)
                 if self.status_banner:
                     self.status_banner.set_status(

--- a/source/ftrack_connect_pipeline_qt/ui/factory/ui_overrides.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/ui_overrides.py
@@ -35,6 +35,7 @@ UI_OVERRIDES = {
     },
     core_constants.FINALIZERS: {
         'show': True,
+        'progress.label.publisher': 'to ftrack',
         'step_container': default_widgets.DefaultStepContainerWidgetObject,
         'step_widget': default_widgets.DefaultStepWidgetObject,
         'stage_widget': default_widgets.DefaultStageWidgetObject,

--- a/source/ftrack_connect_pipeline_qt/ui/utility/widget/definition_selector.py
+++ b/source/ftrack_connect_pipeline_qt/ui/utility/widget/definition_selector.py
@@ -1,12 +1,11 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2015-2022 ftrack
 import logging
-import json
-
 
 from Qt import QtWidgets, QtCore
 
 from ftrack_connect_pipeline.utils import str_version
+from ftrack_connect_pipeline import constants as core_constants
 
 from ftrack_connect_pipeline_qt.ui.utility.widget.circular_button import (
     CircularButton,
@@ -135,7 +134,7 @@ class DefinitionSelectorBase(QtWidgets.QWidget):
                     self.schema = schema
                     break
             self.definitionChanged.emit(
-                self.schema, self.definition, self.component_names_filter
+                self.definition, self.schema, self.component_names_filter
             )
         else:
             self.logger.debug('No data for selected definition')
@@ -227,7 +226,9 @@ class OpenerDefinitionSelector(DefinitionSelectorBase):
                 # can load the file extensions. Peek into versions and pre-select
                 # the one loader having the latest version
                 is_compatible = False
-                for component_step in item['components']:
+                for component_step in item.get_all(
+                    type=core_constants.COMPONENT
+                ):
                     can_open_component = False
                     file_formats = component_step['file_formats']
                     if set(file_formats).intersection(


### PR DESCRIPTION
Resolves : 

* CLICKUP-2yft4xp
* FTRACK-
* SENTRY-
* ZENDESK-

- [X] The PR contains a description of what has been changed.
- [X] The PR contains update to the release notes.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs Intel / Big Sur, Maya 2023
- [ ] Linux.


## Changes

- Use core pipeline DefinitionObject API instead of raw definition dictionary operations.
- Updated progress widget style and appearance of finalizer section.

## Test

_Note: have to be tested on the corresponding backlog/definitionObject/story branches._

Launch DCC application and run a full test cycle.
            