### PR TITLE
Invalid default up axis(x) in Maya FBX exporter

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,12 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fixed
+        :tags: dynamicwidget
+
+        Fixed bug where default plugin option list item were not selected.
+
+
     .. change:: change
         :tags: assembler
 

--- a/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
+++ b/source/ftrack_connect_pipeline_qt/plugin/widget/dynamic.py
@@ -184,6 +184,7 @@ class DynamicWidget(BaseOptionsWidget):
                 # List/combobox definition, parse
                 new_value = []
                 supplied_value = self.options.get(key)
+                default_item = None
                 for item in value:
                     if item is None:
                         item = ''
@@ -195,10 +196,18 @@ class DynamicWidget(BaseOptionsWidget):
                         supplied_value is not None
                         and item['value'] == supplied_value
                     ):
-                        item['default'] = True  # Make sure is is selected
-                    elif supplied_value is None and 'default' in item:
+                        default_item = item
+                    elif 'default' in item:
+                        if default_item is None:
+                            default_item = item
                         del item['default']
                     new_value.append(item)
+                # Set the final default item
+                if default_item:
+                    for item in new_value:
+                        if item == default_item:
+                            item['default'] = True
+                            break
                 options[key] = new_value
             else:
                 if key in self.options:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/3qfxmg3


- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Fixed bug where default plugin option list item were not selected.


## Test

Create a list option that have a default item other than the first one, it should not be selected from start and not the first item in list.
            