### PR TITLE
Error on changing opener asset version to/from a non compatible

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,11 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fix
+        :tags: opener
+
+        Error on changing opener asset version to/from a non compatible.
+
     .. change:: new
         :tags: houdini
 

--- a/source/ftrack_connect_pipeline_qt/plugin/widget/context.py
+++ b/source/ftrack_connect_pipeline_qt/plugin/widget/context.py
@@ -239,11 +239,12 @@ class LoadContextWidget(BaseOptionsWidget):
     ):
         '''Updates the option dicctionary with provided *asset_name* when
         asset_changed of asset_selector event is triggered'''
-        self.set_option_result(asset_name, key='asset_name')
-        self.set_option_result(asset_entity['id'], key='asset_id')
-        self.set_option_result(version_num, key='version_number')
-        self.set_option_result(asset_version_id, key='version_id')
-        self.assetChanged.emit(asset_name, asset_entity['id'], True)
+        if asset_name:
+            self.set_option_result(asset_name, key='asset_name')
+            self.set_option_result(asset_entity['id'], key='asset_id')
+            self.set_option_result(version_num, key='version_number')
+            self.set_option_result(asset_version_id, key='version_id')
+            self.assetChanged.emit(asset_name, asset_entity['id'], True)
         self.assetVersionChanged.emit(asset_version_id)
 
     def _build_asset_selector(self):
@@ -335,12 +336,15 @@ class OpenContextWidget(BaseOptionsWidget):
     ):
         '''Updates the option dictionary with provided *asset_name* when
         asset_changed of asset_selector event is triggered'''
-        self.set_option_result(asset_name, key='asset_name')
-        self.set_option_result(asset_entity['id'], key='asset_id')
-        self.set_option_result(version_num, key='version_number')
-        self.set_option_result(asset_version_id, key='version_id')
+        if asset_name:
+            self.set_option_result(asset_name, key='asset_name')
+            self.set_option_result(asset_entity['id'], key='asset_id')
+            self.set_option_result(version_num, key='version_number')
+            self.set_option_result(asset_version_id, key='version_id')
 
-        self.assetChanged.emit(asset_name, asset_entity['id'], True)
+        self.assetChanged.emit(
+            asset_name, asset_entity['id'] if asset_entity else None, True
+        )
         self.assetVersionChanged.emit(asset_version_id)
 
 

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
@@ -396,12 +396,11 @@ class AssemblerBaseWidget(QtWidgets.QWidget):
                                     if key != core_constants.CONTEXTS:
                                         continue
                                     # Inject context ident
-                                    for plugin in (
-                                        definition_fragment[key]
-                                        .get_all(
-                                            type=core_constants.CONTEXT,
-                                            category=core_constants.PLUGIN
-                                        )
+                                    for plugin in definition_fragment[
+                                        key
+                                    ].get_all(
+                                        type=core_constants.CONTEXT,
+                                        category=core_constants.PLUGIN,
                                     ):
                                         if not 'options' in plugin:
                                             plugin['options'] = {}

--- a/source/ftrack_connect_pipeline_qt/ui/utility/widget/asset_version_list_selector.py
+++ b/source/ftrack_connect_pipeline_qt/ui/utility/widget/asset_version_list_selector.py
@@ -273,6 +273,7 @@ class AssetListSelector(QtWidgets.QFrame):
 
     def _on_current_asset_changed(self, asset_widget):
         '''An existing asset has been selected.'''
+        asset_name = asset_entity = None
         if asset_widget:
             # A proper asset were selected
             asset_entity = asset_widget.asset


### PR DESCRIPTION
Resolves : 

* CLICKUP-https://app.clickup.com/t/3qvbfuy

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Error on changing opener asset version to/from a non compatible

## Test

Publish a scene in Houdini, then go to Maya and publish another scene on the same asset. There should then be no exception in Maya when opening and switching between the two versions.
            