### PR TITLE
feat: Added scroll widget to publisher overlay for large option sets

### DIFF
--- a/source/ftrack_connect_pipeline_qt/ui/factory/overrides/step_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/overrides/step_widget.py
@@ -85,6 +85,7 @@ class PublisherOptionsButton(OptionsButton):
         scroll.setWidget(self._component_options_widget)
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
 
         self.main_widget.layout().addWidget(scroll)
         self.overlay_container = overlay.Overlay(

--- a/source/ftrack_connect_pipeline_qt/ui/factory/overrides/step_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/overrides/step_widget.py
@@ -17,7 +17,7 @@ from ftrack_connect_pipeline_qt.plugin.widget.load_widget import (
 from ftrack_connect_pipeline_qt.ui.utility.widget import line
 from ftrack_connect_pipeline_qt.ui.utility.widget import overlay
 from ftrack_connect_pipeline_qt import utils
-from ftrack_connect_pipeline_qt.ui.utility.widget import icon
+from ftrack_connect_pipeline_qt.ui.utility.widget import icon, scroll_area
 from ftrack_connect_pipeline_qt.plugin.widget import BaseOptionsWidget
 from ftrack_connect_pipeline_qt.ui.utility.widget.accordion import (
     AccordionWidget,
@@ -73,16 +73,23 @@ class PublisherOptionsButton(OptionsButton):
         self.main_widget.setLayout(QtWidgets.QVBoxLayout())
         self.main_widget.layout().setAlignment(QtCore.Qt.AlignTop)
 
-        self._component_options_widget = QtWidgets.QWidget()
-        self._component_options_widget.setLayout(QtWidgets.QVBoxLayout())
         title_label = QtWidgets.QLabel(self._name)
         title_label.setObjectName('h2')
-        self._component_options_widget.layout().addWidget(title_label)
-        self._component_options_widget.layout().addWidget(QtWidgets.QLabel(''))
-        self.main_widget.layout().addWidget(self._component_options_widget)
+        self.main_widget.layout().addWidget(title_label)
+        self.main_widget.layout().addWidget(QtWidgets.QLabel(''))
+
+        self._component_options_widget = QtWidgets.QWidget()
+        self._component_options_widget.setLayout(QtWidgets.QVBoxLayout())
+
+        scroll = scroll_area.ScrollArea()
+        scroll.setWidget(self._component_options_widget)
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+
+        self.main_widget.layout().addWidget(scroll)
         self.overlay_container = overlay.Overlay(
             self.main_widget,
-            height_percentage=0.8,
+            height_percentage=0.9,
             transparent_background=False,
         )
         self.overlay_container.setVisible(False)
@@ -99,7 +106,6 @@ class PublisherOptionsButton(OptionsButton):
 
     def add_validator_widget(self, widget):
         '''Add validator plugin container widget to overlay'''
-        self._component_options_widget.layout().addWidget(QtWidgets.QLabel(''))
         self._component_options_widget.layout().addWidget(line.Line())
         self._component_options_widget.layout().addWidget(QtWidgets.QLabel(''))
         label = QtWidgets.QLabel('Validators:')


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-https://app.clickup.com/t/3rch7zy

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes

Added scroll widget to publisher overlay for large option sets

## Test

Test with FBX publish in 3ds Max
