### PR TITLE
feat: Backlog/shot publisher

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -7,6 +7,14 @@
 Release Notes
 *************
 
+.. release:: upcoming
+
+    .. change:: changed
+        :tags: publisher
+
+        Enable publisher to support switching progress widget (Unreal shot publish)
+
+
 .. release:: 1.3.0
     .. date:: 2023-04-05
 

--- a/source/ftrack_connect_pipeline_qt/client/load/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/load/__init__.py
@@ -378,7 +378,7 @@ class QtAssemblerClientWidget(QtLoaderClient, dialog.Dialog):
     # Run
 
     def setup_widget_factory(self, widget_factory, definition, context_id):
-        widget_factory.set_definition(definition)
+        widget_factory.definition = definition
         widget_factory.set_context(context_id, definition['asset_type'])
         widget_factory.host_connection = self._host_connection
         widget_factory.set_definition_type(definition['type'])

--- a/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/client/publish/__init__.py
@@ -47,10 +47,12 @@ class QtPublisherClientWidget(QtPublisherClient, QtWidgets.QFrame):
 
     @property
     def widget_factory(self):
+        '''Return the widget factory'''
         return self._widget_factory
 
     @widget_factory.setter
     def widget_factory(self, value):
+        '''Set/change the current widget factory from *value*, update main progress widget in header.'''
         self._widget_factory = value
         clear_layout(self.header.content_container.layout())
         self.header.content_container.layout().addWidget(
@@ -59,6 +61,7 @@ class QtPublisherClientWidget(QtPublisherClient, QtWidgets.QFrame):
 
     @property
     def progress_widget(self):
+        '''Return the factory progress widget'''
         return self.widget_factory.progress_widget
 
     def __init__(self, event_manager, parent=None):

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/__init__.py
@@ -600,10 +600,7 @@ class DependenciesListWidget(AssemblerListBaseWidget):
             component_widget.set_component_and_definitions(
                 component, definitions
             )
-            self.layout().addWidget(component_widget)
-            component_widget.clicked.connect(
-                partial(self.asset_clicked, component_widget)
-            )
+            self.add_widget(component_widget)
 
         self.layout().addWidget(QtWidgets.QLabel(), 1000)
         self.refreshed.emit()

--- a/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/assembler/base/__init__.py
@@ -742,7 +742,7 @@ class ComponentBaseWidget(AccordionBaseWidget):
         '''Serialize definition and store'''
         updated_definition = self._widget_factory.to_json_object()
 
-        self._widget_factory.set_definition(updated_definition)
+        self._widget_factory.definition = updated_definition
         # Transfer back load mode
         self._set_default_mode()
         # Clear out overlay, not needed anymore

--- a/source/ftrack_connect_pipeline_qt/ui/asset_manager/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/asset_manager/__init__.py
@@ -501,10 +501,7 @@ class AssetManagerListWidget(AssetListWidget):
                 asset_widget, 'first', 'true' if row == 0 else 'false'
             )
             asset_widget.set_asset_info(asset_info)
-            self.layout().addWidget(asset_widget)
-            asset_widget.clicked.connect(
-                partial(self.asset_clicked, asset_widget)
-            )
+            self.add_widget(asset_widget)
             asset_widget.changeAssetVersion.connect(
                 self._on_change_asset_version
             )

--- a/source/ftrack_connect_pipeline_qt/ui/asset_manager/base/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/asset_manager/base/__init__.py
@@ -246,16 +246,18 @@ class AssetListWidget(QtWidgets.QWidget):
                 return widget
 
     def add_widget(self, widget):
+        '''Add *widget* to the list'''
         self.layout().addWidget(widget)
         self.setup_widget(widget)
 
     def setup_widget(self, widget):
-        '''Initialize accordion asset widget, ignore other types of widget in list'''
+        '''Set up asset *widget* signals'''
         if isinstance(widget, AccordionBaseWidget):
             widget.clicked.connect(partial(self.asset_clicked, widget))
             widget.checkedStateChanged.connect(self.asset_checked)
 
     def asset_checked(self, asset_widget):
+        '''An asset were checked in list, emit signal to enable propagation.'''
         self.checkedUpdated.emit(self.checked())
 
     def mousePressEvent(self, event):

--- a/source/ftrack_connect_pipeline_qt/ui/factory/__init__.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/__init__.py
@@ -702,6 +702,7 @@ class WidgetFactoryBase(QtWidgets.QWidget):
         '''Unsubscribe from :const:`~ftrack_connnect_pipeline.constants.PIPELINE_CLIENT_NOTIFICATION`'''
         if self._subscriber_id:
             self.session.event_hub.unsubscribe(self._subscriber_id)
+            self._subscriber_id = None
 
     def _on_widget_asset_changed(self, asset_name, asset_id, is_valid):
         '''Callback function called when asset has been modified on the widget'''

--- a/source/ftrack_connect_pipeline_qt/ui/factory/assembler.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/assembler.py
@@ -18,12 +18,23 @@ from ftrack_connect_pipeline_qt.ui.factory import (
 class AssemblerWidgetFactory(OpenerAssemblerWidgetFactoryBase):
     '''Augmented widget factory for assembler(loader) client'''
 
+    @property
+    def definition(self):
+        '''Return the definition'''
+        return self._definition
+
+    @definition.setter
+    def definition(self, value):
+        '''Set the definition'''
+        self._definition = value
+
     def __init__(self, event_manager, ui_types, parent=None):
         super(AssemblerWidgetFactory, self).__init__(
             event_manager,
             ui_types,
             parent=parent,
         )
+        self._definition = None
 
     @staticmethod
     def client_type():
@@ -36,9 +47,6 @@ class AssemblerWidgetFactory(OpenerAssemblerWidgetFactoryBase):
         return OpenerAssemblerWidgetFactoryBase.create_progress_widget(
             AssemblerWidgetFactory.client_type(), parent=parent
         )
-
-    def set_definition(self, definition):
-        self.definition = definition
 
     def build(self, main_widget):
         '''(Override)'''

--- a/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
@@ -292,7 +292,9 @@ class ProgressWidgetObject(BaseUIWidgetObject):
         batch_id,
         batch_ident=None,
     ):
-        '''Update the status of the progress of a step/component'''
+        '''Update the status of the progress, given by *status*, *status_message*, *result*
+        of a step/component identified by *step_type*, *step_name*, *batch_id*. Use optional *batch_ident*
+        as label instead of batch_id if provided.'''
         id_name = "{}.{}.{}".format(batch_id or '-', step_type, step_name)
         if id_name in self._step_widgets:
             self._step_widgets[id_name].update_status(

--- a/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
+++ b/source/ftrack_connect_pipeline_qt/ui/factory/default/progress_widget.py
@@ -283,7 +283,14 @@ class ProgressWidgetObject(BaseUIWidgetObject):
         self.widget.setVisible(visibility)
 
     def update_step_status(
-        self, step_type, step_name, status, status_message, results, batch_id
+        self,
+        step_type,
+        step_name,
+        status,
+        status_message,
+        results,
+        batch_id,
+        batch_ident=None,
     ):
         '''Update the status of the progress of a step/component'''
         id_name = "{}.{}.{}".format(batch_id or '-', step_type, step_name)
@@ -293,7 +300,9 @@ class ProgressWidgetObject(BaseUIWidgetObject):
             )
             if status != self.widget.get_status():
                 main_status_message = '{}{}.{}: {}'.format(
-                    ('{}.'.format(batch_id)) if batch_id else '',
+                    '{}.'.format(batch_ident)
+                    if batch_ident
+                    else ('{}.'.format(batch_id) if batch_id else ''),
                     step_type,
                     step_name,
                     status_message,


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865c3weeu
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [X] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes

- Support for dynamic publisher widget factory, to accomdate Unreal shot publisher
- Brought over additional improvements from Unreal regarding list widget item add and progress widget status updates
- Use proper definition getter and setter on widget factory

## Test

Should be tested with corresponding branches on pipeline, QT and Unreal.